### PR TITLE
varnish api is included these days

### DIFF
--- a/chef/cookbooks/berks/varnish_ng/recipes/install.rb
+++ b/chef/cookbooks/berks/varnish_ng/recipes/install.rb
@@ -58,7 +58,7 @@ when 'debian'
     action node['varnish']['apt']['action']
   end
 
-  %w(apt-transport-https varnish libvarnishapi-dev).each do |p|
+  %w(apt-transport-https varnish).each do |p|
     package p
   end
 end


### PR DESCRIPTION
it looks like the varnish_ng version we are using is as high as it goes, we should probably propagate.